### PR TITLE
Make NodePort not so great again

### DIFF
--- a/helm/alvin/values.yaml
+++ b/helm/alvin/values.yaml
@@ -36,6 +36,7 @@ externalAccess:
   loginPathSystem: /login/rest/
   alvinClientPath: alvinclient
 port:
+  nodePort: true
   apache: 30981
 apache:
   useExtraEnvs: true

--- a/helm/cora/templates/cora-apache.tpl
+++ b/helm/cora/templates/cora-apache.tpl
@@ -48,12 +48,16 @@ kind: Service
 metadata:
   name: apache
 spec:
+  {{- if .Values.port.nodePort }}
   type: NodePort
+  {{- end }}
   selector:
     app: {{ .Values.system.name }}-apache
   ports:
     - protocol: TCP
       port: 80
       targetPort: 80
+      {{- if .Values.port.nodePort }}
       nodePort:  {{ .Values.port.apache }}
+      {{- end }}
 {{- end }}

--- a/helm/diva/templates/playwright.yaml
+++ b/helm/diva/templates/playwright.yaml
@@ -53,14 +53,18 @@ kind: Service
 metadata:
   name: {{ .Values.system.name }}-playwright
 spec:
+  {{- if .Values.port.nodePort }}
   type: NodePort
+  {{- end }}
   selector:
     app: {{ .Values.system.name }}-playwright
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 8080
+      {{- if .Values.port.nodePort }}
       nodePort:  {{ .Values.port.playwright }}
+      {{- end }}
 
 {{- end }}
 

--- a/helm/diva/values.yaml
+++ b/helm/diva/values.yaml
@@ -39,6 +39,7 @@ externalAccess:
   applicationName: diva
   loginPathSystem: /login/rest/
 port:
+  nodePort: true
   apache: 30982
 apache:
   useExtraEnvs: true


### PR DESCRIPTION
Syntax::

  port:
    nodePort: false|true

Default value is true in order to maintain backwards compatibility with existing CI pipelines.

Switching nodePort to false converts NodePort objects into ClusterIP, thus making possible to deploy many SVC instances at once without port conflicts

Required for production clusters